### PR TITLE
Add SLES deployment script

### DIFF
--- a/deployments/aws/sles_server/README.md
+++ b/deployments/aws/sles_server/README.md
@@ -1,0 +1,4 @@
+# How to use
+
+This deployment consist in one or more SLES or SLES4SAP virtual machines on AWS EC2. This allow to have an arbitrary group of machines under the same vpc and that can be added and removed with ease, just by modifying the variable configuration.
+Each machine is configured with a registration code so that at startup the system is registered at SUSE Custom Center for license activation.

--- a/deployments/aws/sles_server/init_script.tpl
+++ b/deployments/aws/sles_server/init_script.tpl
@@ -1,0 +1,5 @@
+#!/bin/bash
+sudo SUSEConnect -r ${license_key} -e ${license_email}
+sudo SUSEConnect -p sle-module-basesystem/${sles_version}/x86_64
+sudo SUSEConnect -p PackageHub/${sles_version}/x86_64
+sudo SUSEConnect -p sle-module-containers/${sles_version}/x86_64

--- a/deployments/aws/sles_server/main.tf
+++ b/deployments/aws/sles_server/main.tf
@@ -1,0 +1,208 @@
+locals {
+  deployment_name       = var.deployment_name != "" ? var.deployment_name : terraform.workspace
+  public_key            = fileexists(var.public_key) ? file(var.public_key) : var.public_key
+  subnet_address_ranges = [cidrsubnet(var.vpc_address_range, 8, 1), cidrsubnet(var.vpc_address_range, 8, 2)]
+  server_ip             = cidrhost(cidrsubnet(var.vpc_address_range, 8, 0), 5)
+  machines = [for i, machine in var.machines : {
+    name       = "${local.deployment_name}-server-${machine.name}"
+    image_id   = machine.image_id
+    private_ip = cidrhost(cidrsubnet(var.vpc_address_range, 8, 0), 5 + i)
+    init_script = templatefile("${path.module}/init_script.tpl",
+      {
+        license_key   = machine.license_key
+        license_email = var.license_email
+        sles_version  = machine.sles_version
+      }
+    )
+  }]
+}
+
+resource "aws_key_pair" "key_pair" {
+  key_name   = "${local.deployment_name} - terraform"
+  public_key = local.public_key
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_vpc" "vpc" {
+  cidr_block           = var.vpc_address_range
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name      = "${local.deployment_name}-vpc"
+    Workspace = local.deployment_name
+  }
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name      = "${local.deployment_name}-igw"
+    Workspace = local.deployment_name
+  }
+}
+
+resource "aws_subnet" "infra" {
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = cidrsubnet(var.vpc_address_range, 8, 0)
+  availability_zone = element(data.aws_availability_zones.available.names, 0)
+
+  tags = {
+    Name      = "${local.deployment_name}-infra-subnet"
+    Workspace = local.deployment_name
+  }
+}
+
+resource "aws_route_table_association" "infra" {
+  subnet_id      = aws_subnet.infra.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_eip" "ngw" {
+  vpc = true
+
+  tags = {
+    Name      = "${local.deployment_name}-eip-ngw"
+    Workspace = local.deployment_name
+  }
+
+  depends_on = [aws_internet_gateway.igw]
+}
+
+resource "aws_nat_gateway" "ngw" {
+  connectivity_type = "public"
+  allocation_id     = aws_eip.ngw.id
+  subnet_id         = aws_subnet.public.id
+
+  tags = {
+    Name      = "${local.deployment_name}-ngw"
+    Workspace = local.deployment_name
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = cidrsubnet(var.vpc_address_range, 8, 254)
+  availability_zone       = element(data.aws_availability_zones.available.names, 0)
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name      = "${local.deployment_name}-public-subnet"
+    Workspace = local.deployment_name
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name      = "${local.deployment_name}-route-table-public"
+    Workspace = local.deployment_name
+  }
+
+  depends_on = [aws_nat_gateway.ngw]
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route" "public" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+}
+
+resource "aws_security_group" "secgroup" {
+  name   = "${local.deployment_name}-sg"
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name      = "${local.deployment_name}-sg"
+    Workspace = local.deployment_name
+  }
+}
+
+resource "aws_security_group_rule" "outall" {
+  type        = "egress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = aws_security_group.secgroup.id
+}
+
+resource "aws_security_group_rule" "local" {
+  type        = "ingress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = [var.vpc_address_range]
+
+  security_group_id = aws_security_group.secgroup.id
+}
+
+resource "aws_security_group_rule" "ssh" {
+  type        = "ingress"
+  from_port   = 22
+  to_port     = 22
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = aws_security_group.secgroup.id
+}
+
+resource "aws_security_group_rule" "http" {
+  type        = "ingress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = aws_security_group.secgroup.id
+}
+
+resource "aws_security_group_rule" "https" {
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = aws_security_group.secgroup.id
+}
+
+resource "aws_instance" "server" {
+  count                       = length(local.machines)
+  ami                         = element(local.machines, count.index).image_id
+  instance_type               = var.instance_type
+  key_name                    = aws_key_pair.key_pair.key_name
+  associate_public_ip_address = true
+  subnet_id                   = aws_subnet.infra.id
+  private_ip                  = element(local.machines, count.index).private_ip
+  vpc_security_group_ids      = [aws_security_group.secgroup.id]
+  availability_zone           = element(data.aws_availability_zones.available.names, 0)
+
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = "60"
+  }
+
+  volume_tags = {
+    Name = "${element(local.machines, count.index).name}-volume-${count.index + 1}"
+  }
+
+  tags = {
+    Name      = element(local.machines, count.index).name
+    Workspace = var.deployment_name
+  }
+
+  user_data = element(local.machines, count.index).init_script
+
+}

--- a/deployments/aws/sles_server/outputs.tf
+++ b/deployments/aws/sles_server/outputs.tf
@@ -11,4 +11,3 @@ output "machines" {
 output "vpc_id" {
   value = aws_vpc.vpc.id
 }
-

--- a/deployments/aws/sles_server/outputs.tf
+++ b/deployments/aws/sles_server/outputs.tf
@@ -1,0 +1,14 @@
+
+
+output "machines" {
+  value = [for instance in aws_instance.server : ({
+    name       = instance.tags_all["Name"]
+    private_ip = instance.private_ip
+    public_ip  = instance.public_ip
+  })]
+}
+
+output "vpc_id" {
+  value = aws_vpc.vpc.id
+}
+

--- a/deployments/aws/sles_server/terraform.tfvars.example
+++ b/deployments/aws/sles_server/terraform.tfvars.example
@@ -1,0 +1,21 @@
+deployment_name   = "my-deployment"
+aws_region        = "eu-central-1"
+aws_access_key_id = "my-aws-access-key-id"
+aws_secret_key    = "my-aws-secret-key"
+public_key        = "path/to/key.pub"
+license_email     = "name.surname@suse.com"
+vpc_address_range = "10.1.0.0/16"
+machines = [
+  {
+    name         = "server1"
+    image_id     = "ami-1234567876543"
+    license_key  = "my-sles-key"
+    sles_version = "15.5"
+  },
+  {
+    name         = "server2"
+    image_id     = "ami-9876543456"
+    license_key  = "m-other-sles-key"
+    sles_version = "15.6"
+  },
+]

--- a/deployments/aws/sles_server/variables.tf
+++ b/deployments/aws/sles_server/variables.tf
@@ -1,0 +1,58 @@
+variable "deployment_name" {
+  description = "Suffix string added to some of the infrastructure resources names. If it is not provided, the terraform workspace string is used as suffix"
+  type        = string
+  default     = ""
+}
+
+variable "aws_region" {
+  description = "AWS region where the deployment machines will be created. If not provided the current configured region will be used"
+  type        = string
+}
+
+variable "aws_access_key_id" {
+  description = "AWS access key id"
+  type        = string
+}
+
+variable "aws_secret_key" {
+  description = "AWS secret key"
+  type        = string
+}
+
+variable "vpc_address_range" {
+  description = "vpc address range in CIDR notation"
+  type        = string
+  default     = "10.0.0.0/16"
+  validation {
+    condition = (
+      can(regex("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$", var.vpc_address_range))
+    )
+    error_message = "Invalid IP range format. It must be something like: 102.168.10.5/24 ."
+  }
+}
+
+variable "public_key" {
+  description = "Content of a SSH public key or path to an already existing SSH public key. The key is only used to provision the machines and it is authorized for future accesses"
+  type        = string
+}
+
+variable "instance_type" {
+  type    = string
+  default = "r3.8xlarge"
+}
+
+variable "license_email" {
+  description = "SLES4SAP license email"
+  type        = string
+}
+
+variable "machines" {
+  description = "List of machines to be created. Each machine is a map with the following keys: image_id, private_ip, version_slug, init_script"
+  type = list(object({
+    name         = string
+    image_id     = string
+    sles_version = string
+    license_key  = string
+  }))
+  default = []
+}

--- a/deployments/aws/sles_server/version.tf
+++ b/deployments/aws/sles_server/version.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.1.0"
+    }
+  }
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  region     = var.aws_region
+  access_key = var.aws_access_key_id
+  secret_key = var.aws_secret_key
+}


### PR DESCRIPTION
This script makes it easier to set up and tear down an arbitrary group of SLES/SLES4SAP instances and having their license registered on SUSE Customer Center, so that they are ready to operate.